### PR TITLE
Allow LightNodeJs examples to run using streamr-docker-dev environment

### DIFF
--- a/LightNodeJs/README.md
+++ b/LightNodeJs/README.md
@@ -34,26 +34,51 @@ The Streamr JavaScript Client imports and runs a Streamr light node as a library
 
 ______________________________________________________
 
-Running the examples:
+### Running the examples:
 ```shell
-$ npm run subscribe
-$ npm run unsubscribe
-$ npm run unsubscribeAll
-$ npm run getSubscriptions
-$ npm run resend
-$ npm run createStream
-$ npm run getStream
-$ npm run getOrCreateStream
-$ npm run publish
-$ npm run searchStream
-$ npm run stream:addToStorageNode
-$ npm run stream:publish
-$ npm run stream:delete
-$ npm run stream:getStorageNodes
-$ npm run stream:removeFromStorageNode
-$ npm run stream:hasPermission
-$ npm run stream:getPermissions
-$ npm run stream:grantPermissions
-$ npm run stream:revokePermissions
-$ npm run stream:update
+npm run subscribe
+npm run unsubscribe
+npm run unsubscribeAll
+npm run getSubscriptions
+npm run resend
+npm run createStream
+npm run getStream
+npm run getOrCreateStream
+npm run publish
+npm run searchStream
+npm run stream:addToStorageNode
+npm run stream:publish
+npm run stream:delete
+npm run stream:getStorageNodes
+npm run stream:removeFromStorageNode
+npm run stream:hasPermission
+npm run stream:getPermissions
+npm run stream:grantPermissions
+npm run stream:revokePermissions
+npm run stream:update
+```
+
+### Running the examples using dev environment:
+To run the examples with a local dev environment ([streamr-docker-dev](https://github.com/streamr-dev/streamr-docker-dev)) pass an extra argument `--dev`
+```shell
+npm run subscribe -- --dev
+npm run unsubscribe -- --dev
+npm run unsubscribeAll -- --dev
+npm run getSubscriptions -- --dev
+npm run resend -- --dev
+npm run createStream -- --dev
+npm run getStream -- --dev
+npm run getOrCreateStream -- --dev
+npm run publish -- --dev
+npm run searchStream -- --dev
+npm run stream:addToStorageNode -- --dev
+npm run stream:publish -- --dev
+npm run stream:delete -- --dev
+npm run stream:getStorageNodes -- --dev
+npm run stream:removeFromStorageNode -- --dev
+npm run stream:hasPermission -- --dev
+npm run stream:getPermissions -- --dev
+npm run stream:grantPermissions -- --dev
+npm run stream:revokePermissions -- --dev
+npm run stream:update -- --dev
 ```

--- a/LightNodeJs/src/createStream.js
+++ b/LightNodeJs/src/createStream.js
@@ -1,10 +1,12 @@
-const { StreamrClient } = require("streamr-client");
+const StreamrClient = require("streamr-client");
 const utils = require("./utils.js");
 const { PrivateKey } = require("./config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/getOrCreateStream.js
+++ b/LightNodeJs/src/getOrCreateStream.js
@@ -4,7 +4,9 @@ const { PrivateKey } = require("./config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/getStream.js
+++ b/LightNodeJs/src/getStream.js
@@ -4,7 +4,9 @@ const { PrivateKey } = require("./config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/getSubscriptions.js
+++ b/LightNodeJs/src/getSubscriptions.js
@@ -4,7 +4,9 @@ const { PrivateKey } = require("./config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/publish.js
+++ b/LightNodeJs/src/publish.js
@@ -6,7 +6,9 @@ const main = async () => {
     try {
       utils.isValidPrivateKey(PrivateKey);
       // Create the client using the validated private key
+      const clientConfig = utils.getClientConfig(process.argv);
       const client = new StreamrClient({
+        ...clientConfig,
         auth: {
           privateKey: PrivateKey,
         },

--- a/LightNodeJs/src/resend.js
+++ b/LightNodeJs/src/resend.js
@@ -1,17 +1,17 @@
-const {
-  STREAMR_STORAGE_NODE_GERMANY,
-  StreamrClient,
-} = require("streamr-client");
+const StreamrClient = require("streamr-client");
 const utils = require("./utils.js");
 const { PrivateKey } = require("./config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },
   });
+  const storageNodeAddress = utils.getStorageNodeAddress(process.argv);
 
   // Create the default stream
   const stream = await client.getOrCreateStream({
@@ -20,7 +20,7 @@ const main = async () => {
 
   const storageNodes = await stream.getStorageNodes();
   if (storageNodes.length === 0) {
-    await stream.addToStorageNode(STREAMR_STORAGE_NODE_GERMANY);
+    await stream.addToStorageNode(storageNodeAddress);
     console.log("Stream added to storage node");
   }
 

--- a/LightNodeJs/src/searchStream.js
+++ b/LightNodeJs/src/searchStream.js
@@ -4,7 +4,9 @@ const { PrivateKey } = require("./config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/stream/addToStorageNode.js
+++ b/LightNodeJs/src/stream/addToStorageNode.js
@@ -1,18 +1,18 @@
-const {
-  STREAMR_STORAGE_NODE_GERMANY,
-  StreamrClient,
-} = require("streamr-client");
+const StreamrClient = require("streamr-client");
 const utils = require("../utils.js");
 const { PrivateKey } = require("../config.js");
 
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },
   });
+  const storageNodeAddress = utils.getStorageNodeAddress(process.argv);
 
   // Create the default stream
   const stream = await client.getOrCreateStream({
@@ -21,7 +21,7 @@ const main = async () => {
   console.log("fetched/created stream", stream.id);
   const storageNodes = await stream.getStorageNodes();
   if (storageNodes.length === 0) {
-    await stream.addToStorageNode(STREAMR_STORAGE_NODE_GERMANY);
+    await stream.addToStorageNode(storageNodeAddress);
     console.log("Stream added to storage node");
   } else {
     console.log("stream was already in storage node");

--- a/LightNodeJs/src/stream/delete.js
+++ b/LightNodeJs/src/stream/delete.js
@@ -1,11 +1,13 @@
-const { StreamrClient } = require("streamr-client");
+const StreamrClient = require("streamr-client");
 const utils = require("../utils.js");
 const { PrivateKey } = require("../config.js");
 
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/stream/getStorageNodes.js
+++ b/LightNodeJs/src/stream/getStorageNodes.js
@@ -1,16 +1,18 @@
-const { STREAMR_STORAGE_NODE_GERMANY, StreamrClient } =
-  require("streamr-client").StreamrClient;
+const { StreamrClient } = require("streamr-client").StreamrClient;
 const utils = require("../utils.js");
 const { PrivateKey } = require("../config.js");
 
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },
   });
+  const storageNodeAddress = utils.getStorageNodeAddress(process.argv);
 
   // Create the default stream
   const stream = await client.getOrCreateStream({
@@ -19,7 +21,7 @@ const main = async () => {
 
   console.log("fetched/created stream", stream.id);
   if ((await stream.getStorageNodes().length) === 0) {
-    await stream.addToStorageNode(STREAMR_STORAGE_NODE_GERMANY);
+    await stream.addToStorageNode(storageNodeAddress);
   }
 
   const storageNodes = await stream.getStorageNodes();

--- a/LightNodeJs/src/stream/permissions/getPermissions.js
+++ b/LightNodeJs/src/stream/permissions/getPermissions.js
@@ -1,11 +1,13 @@
-const { StreamrClient } = require("streamr-client");
+const StreamrClient = require("streamr-client");
 const utils = require("../../utils.js");
 const { PrivateKey } = require("../../config.js");
 
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/stream/permissions/grantPermissions.js
+++ b/LightNodeJs/src/stream/permissions/grantPermissions.js
@@ -5,7 +5,9 @@ const { PrivateKey } = require("../../config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/stream/permissions/hasPermission.js
+++ b/LightNodeJs/src/stream/permissions/hasPermission.js
@@ -5,7 +5,9 @@ const { PrivateKey } = require("../../config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/stream/permissions/revokePermissions.js
+++ b/LightNodeJs/src/stream/permissions/revokePermissions.js
@@ -5,7 +5,9 @@ const { PrivateKey } = require("../../config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/stream/publish.js
+++ b/LightNodeJs/src/stream/publish.js
@@ -1,4 +1,4 @@
-const { StreamrClient } = require("streamr-client");
+const StreamrClient = require("streamr-client");
 const utils = require("../utils.js");
 const { PrivateKey } = require("../config.js");
 
@@ -7,7 +7,9 @@ const main = async () => {
     try {
       utils.isValidPrivateKey(PrivateKey);
       // Create the client using the validated private key
+      const clientConfig = utils.getClientConfig(process.argv);
       const client = new StreamrClient({
+        ...clientConfig,
         auth: {
           privateKey: PrivateKey,
         },

--- a/LightNodeJs/src/stream/removeFromStorageNode.js
+++ b/LightNodeJs/src/stream/removeFromStorageNode.js
@@ -1,16 +1,18 @@
-const { STREAMR_STORAGE_NODE_GERMANY, StreamrClient } =
-  require("streamr-client").StreamrClient;
+const { StreamrClient } = require("streamr-client").StreamrClient;
 const utils = require("../utils.js");
 const { PrivateKey } = require("../config.js");
 
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },
   });
+  const storageNodeAddress = utils.getStorageNodeAddress(process.argv);
 
   // Create the default stream
   const stream = await client.getOrCreateStream({
@@ -19,10 +21,10 @@ const main = async () => {
 
   console.log("fetched/created stream", stream.id);
   if ((await stream.getStorageNodes().length) === 0) {
-    await stream.addToStorageNode(STREAMR_STORAGE_NODE_GERMANY);
+    await stream.addToStorageNode(storageNodeAddress);
   }
 
-  await stream.removeFromStorageNode(STREAMR_STORAGE_NODE_GERMANY);
+  await stream.removeFromStorageNode(storageNodeAddress);
   console.log("Stream removed from storage node");
   await client.destroy();
   return stream.id;

--- a/LightNodeJs/src/stream/update.js
+++ b/LightNodeJs/src/stream/update.js
@@ -6,7 +6,9 @@ const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
 
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/subscribe.js
+++ b/LightNodeJs/src/subscribe.js
@@ -4,7 +4,9 @@ const { PrivateKey } = require("./config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/unsubscribe.js
+++ b/LightNodeJs/src/unsubscribe.js
@@ -4,7 +4,9 @@ const { PrivateKey } = require("./config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },

--- a/LightNodeJs/src/unsubscribeAll.js
+++ b/LightNodeJs/src/unsubscribeAll.js
@@ -7,7 +7,9 @@ const { PrivateKey } = require("./config.js");
 const main = async () => {
   utils.isValidPrivateKey(PrivateKey);
   // Create the client using the validated private key
+  const clientConfig = utils.getClientConfig(process.argv);
   const client = new StreamrClient({
+    ...clientConfig,
     auth: {
       privateKey: PrivateKey,
     },
@@ -24,7 +26,7 @@ const main = async () => {
   const streams = await client.unsubscribe();
   console.log(`Unsubscribed from all streams`);
   console.log(streams);
-  await client.destroy;
+  await client.destroy();
   return stream.id;
 };
 

--- a/LightNodeJs/src/utils.js
+++ b/LightNodeJs/src/utils.js
@@ -1,5 +1,6 @@
 const { Wallet } = require("ethers");
-const { PrivateKey } = require("./config.js");
+const { CONFIG_TEST, STREAMR_STORAGE_NODE_GERMANY } = require("streamr-client");
+const STREAMR_STORAGE_NODE_DOCKER = "0xde1112f631486CfC759A50196853011528bC5FA0";
 module.exports = {
   isValidPrivateKey: (privateKey) => {
     try {
@@ -14,6 +15,24 @@ module.exports = {
 
   isRunFlagPresent: (args) => {
     args = args.slice(2);
-    return args.length > 0 && args[0] === "--run";
+    return args.includes("--run");
   },
+
+  getClientConfig: (args) => {
+    args = args.slice(2);
+    if (args.includes("--dev")) {
+      return CONFIG_TEST
+    }
+
+    return {}
+  },
+
+  getStorageNodeAddress: (args) => {
+    args = args.slice(2);
+    if (args.includes("--dev")) {
+      return STREAMR_STORAGE_NODE_DOCKER
+    }
+
+    return STREAMR_STORAGE_NODE_GERMANY
+  }
 };


### PR DESCRIPTION
The provided changes make `LightNodeJs` examples run against [streamr-docker-dev](https://github.com/streamr-dev/streamr-docker-dev) environment.

To run the examples with a local dev environment ([streamr-docker-dev](https://github.com/streamr-dev/streamr-docker-dev)) pass an extra argument `--dev`. For example:

```
npm run publish -- --dev
```

See [README.md](https://github.com/usherlabs/streamr-examples/blob/master/LightNodeJs/README.md) for more details.